### PR TITLE
Add more clustering options and change default report generation mode

### DIFF
--- a/bin/plotting_utils.py
+++ b/bin/plotting_utils.py
@@ -10,7 +10,8 @@ import os
 import workflow_utils as ut
 
 
-def dimred_2D_html(dimred_path: str, labels_path: str, component_1: int=0, component_2: int=1) -> str:
+def dimred_2D_html(dimred_path: str, labels_path: str, component_1: int=0, component_2: int=1,
+                   include_plotlyjs: str | bool = 'cdn') -> str:
     dimred = np.load(dimred_path)
     labels = np.load(labels_path)
 
@@ -18,25 +19,25 @@ def dimred_2D_html(dimred_path: str, labels_path: str, component_1: int=0, compo
 
     fig = plot_dimred_2D_labelled(data)
 
-    plot_html = fig.to_html(full_html = False)
+    plot_html = fig.to_html(full_html = False, include_plotlyjs=include_plotlyjs)
 
     return plot_html
 
-def img_html(img_path: str) -> str:
+def img_html(img_path: str, include_plotlyjs: str | bool = 'cdn') -> str:
     img = ut.read_img(img_path)
 
     fig = plot_img(img)
 
-    plot_html = fig.to_html(full_html = False)
+    plot_html = fig.to_html(full_html = False, include_plotlyjs=include_plotlyjs)
 
     return plot_html
 
-def img_downscaled_html(img_path: str, size=(400, 400)) -> str:
+def img_downscaled_html(img_path: str, size=(400, 400), include_plotlyjs: str | bool = 'cdn') -> str:
     img = ut.read_img(img_path)
 
     fig = plot_img_downscaled(img, size)
 
-    plot_html = fig.to_html(full_html = False)
+    plot_html = fig.to_html(full_html = False, include_plotlyjs=include_plotlyjs)
 
     return plot_html
 

--- a/bin/run_hdbscan.py
+++ b/bin/run_hdbscan.py
@@ -2,6 +2,7 @@
 
 import hdbscan
 from sklearn.cluster import KMeans, AffinityPropagation
+from sklearn.mixture import GaussianMixture
 import fire
 import numpy as np
 import workflow_utils as ut
@@ -20,7 +21,6 @@ def run_hdbscan(
     hdbscan_labels = hdbscan.HDBSCAN(min_samples=min_samples, min_cluster_size=min_cluster_size, **kwargs).fit_predict(data)
     np.save(savefile, hdbscan_labels)
 
-
 def run_kmeans(
     np_data_path: str, 
     savefile: str='clustering_labels.npy', 
@@ -35,7 +35,15 @@ def run_affinity_propagation(
     **kwargs) -> None:
     data = np.load(np_data_path)
     affprop_labels = AffinityPropagation(**kwargs).fit_predict(data)
-    np.save(savefile, affprop_labels)    
+    np.save(savefile, affprop_labels)
+
+def run_gaussian_mixture(
+    np_data_path: str, 
+    savefile: str='clustering_labels.npy', 
+    **kwargs) -> None:
+    data = np.load(np_data_path)
+    gauss_mix_labels = GaussianMixture(**kwargs).fit_predict(data)
+    np.save(savefile, gauss_mix_labels)
     
 def run_leiden(
     np_data_path: str, 
@@ -66,6 +74,9 @@ def main(np_data_path: str, params_str: str) -> None:
     elif method == 'affinity_propagation':
         run_affinity_propagation(np_data_path=np_data_path, 
                                  **params_dict)
+    elif method == 'gaussian_mixture':
+        run_gaussian_mixture(np_data_path=np_data_path, 
+                             **params_dict)
     else:
         raise ValueError(f'Clustering method \"{method}\" is not a valid option.')
 

--- a/bin/run_hdbscan.py
+++ b/bin/run_hdbscan.py
@@ -58,9 +58,6 @@ def run_leiden(
     lied_clust = ad.obs['leiden']
     leid_clust = np.array([int(x) for x in lied_clust])
     np.save(savefile, leid_clust)
-    # probably need to use scanpy.tl.leiden
-    # for that I have to convert the data into an AnnData object
-    # raise ValueError("Leiden clustering is not implemented yet.")
 
 def main(np_data_path: str, params_str: str) -> None:
     params_dict = ut.parse_params_str(params_str)

--- a/bin/run_hdbscan.py
+++ b/bin/run_hdbscan.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import hdbscan
-from sklearn.cluster import KMeans
+from sklearn.cluster import KMeans, AffinityPropagation
 import fire
 import numpy as np
 import workflow_utils as ut
@@ -28,7 +28,15 @@ def run_kmeans(
     data = np.load(np_data_path)
     kmeans_labels = KMeans(**kwargs).fit_predict(data)
     np.save(savefile, kmeans_labels)
-
+    
+def run_affinity_propagation(
+    np_data_path: str, 
+    savefile: str='clustering_labels.npy', 
+    **kwargs) -> None:
+    data = np.load(np_data_path)
+    affprop_labels = AffinityPropagation(**kwargs).fit_predict(data)
+    np.save(savefile, affprop_labels)    
+    
 def run_leiden(
     np_data_path: str, 
     savefile: str='clustering_labels.npy', 
@@ -55,6 +63,9 @@ def main(np_data_path: str, params_str: str) -> None:
     elif method == 'leiden':
         run_leiden(np_data_path=np_data_path,
                     **params_dict)
+    elif method == 'affinity_propagation':
+        run_affinity_propagation(np_data_path=np_data_path, 
+                                 **params_dict)
     else:
         raise ValueError(f'Clustering method \"{method}\" is not a valid option.')
 

--- a/bin/run_hdbscan.py
+++ b/bin/run_hdbscan.py
@@ -83,9 +83,6 @@ def main(np_data_path: str, params_str: str) -> None:
     elif method == 'gaussian_mixture':
         run_gaussian_mixture(np_data_path=np_data_path, 
                              **params_dict)
-    elif method == 'leiden':
-        run_leiden(np_data_path=np_data_path, 
-                   **params_dict)
     else:
         raise ValueError(f'Clustering method \"{method}\" is not a valid option.')
 

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -1,4 +1,4 @@
-name: dimas_env
+name: environment
 channels:
   - plotly
   - anaconda
@@ -120,4 +120,3 @@ dependencies:
       - umap-learn==0.5.5
       - wcwidth==0.2.12
       - zarr==2.16.1
-prefix: /lustre/scratch126/casm/team268im/os9/conda/envs/dimas_env

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -1,4 +1,4 @@
-name: environment
+name: dimas_env
 channels:
   - plotly
   - anaconda
@@ -38,7 +38,6 @@ dependencies:
   - setuptools=68.2.2=py311h06a4308_0
   - six=1.16.0=pyhd3eb1b0_1
   - sqlite=3.41.2=h5eee18b_0
-  - stack_data=0.2.0=pyhd3eb1b0_0
   - tenacity=8.2.2=py311h06a4308_0
   - tk=8.6.12=h1ccaba5_0
   - tornado=6.3.3=py311h5eee18b_0
@@ -47,6 +46,8 @@ dependencies:
   - zeromq=4.3.4=h2531618_0
   - zlib=1.2.13=h5eee18b_0
   - pip:
+      - anndata==0.10.8
+      - array-api-compat==1.7.1
       - asciitree==0.3.3
       - asttokens==2.4.1
       - comm==0.2.0
@@ -61,7 +62,9 @@ dependencies:
       - fire==0.5.0
       - fonttools==4.45.0
       - fsspec==2023.10.0
+      - h5py==3.11.0
       - hdbscan==0.8.33
+      - igraph==0.11.6
       - imagecodecs==2023.9.18
       - imageio==2.33.0
       - ipykernel==6.27.0
@@ -70,10 +73,13 @@ dependencies:
       - joblib==1.3.2
       - kiwisolver==1.4.5
       - lazy-loader==0.3
+      - legacy-api-wrap==1.4
+      - leidenalg==0.10.2
       - llvmlite==0.41.1
       - lxml==4.9.3
       - matplotlib==3.8.2
       - memory-profiler==0.61.0
+      - natsort==8.4.0
       - nest-asyncio==1.5.8
       - networkx==3.2.1
       - numba==0.58.1
@@ -81,6 +87,7 @@ dependencies:
       - numpy==1.26.2
       - packaging==23.2
       - pandas==2.1.3
+      - patsy==0.5.6
       - pillow==10.1.0
       - platformdirs==4.0.0
       - prompt-toolkit==3.0.41
@@ -91,12 +98,18 @@ dependencies:
       - pytz==2023.3.post1
       - pyyaml==6.0.1
       - pyzmq==25.1.1
+      - scanpy==1.10.2
       - scikit-image==0.22.0
       - scikit-learn==1.3.2
       - scipy==1.11.4
+      - seaborn==0.13.2
+      - session-info==1.0.0
       - stack-data==0.6.3
+      - statsmodels==0.14.2
+      - stdlib-list==0.10.0
       - termcolor==2.3.0
       - textalloc==0.0.11
+      - texttable==1.7.0
       - threadpoolctl==3.2.0
       - tifffile==2023.9.26
       - tiffslide==2.4.0
@@ -107,3 +120,4 @@ dependencies:
       - umap-learn==0.5.5
       - wcwidth==0.2.12
       - zarr==2.16.1
+prefix: /lustre/scratch126/casm/team268im/os9/conda/envs/dimas_env

--- a/grid_search.nf
+++ b/grid_search.nf
@@ -187,6 +187,7 @@ process get_tissue_mask {
 
 process downscale_mask {
     debug debug_flag
+    tag "preprocessing"
     // publishDir "${step_outdir}", mode: "copy"
 
     input:
@@ -207,6 +208,7 @@ process downscale_mask {
 
 process fastlbp {
     debug debug_flag
+    tag "fastlbp"
     // publishDir "${step_outdir}", mode: "copy"
 
     input:
@@ -272,6 +274,7 @@ process clustering {
 
 process labels_to_patch_img {
     debug debug_flag
+    tag "generating segmented image"
     // publishDir "${step_outdir}", mode: "copy"
 
     input:

--- a/grid_search.nf
+++ b/grid_search.nf
@@ -25,6 +25,7 @@ def extract_patchsize_from_lbp_params_list(lbp_params_list) {
 }
 
 // TODO: refactor
+// BUG: works incorrectly with string parameters
 def createCombinations(method_params) {
     // total number of parameters for the method
     def method_params_num = method_params.size()
@@ -636,6 +637,7 @@ workflow SingleImage {
             .combine(hdbscan_combinations_hash_outdir)
             .map { umap_outdir, umap_embeddings, hdbscan_params_str, hdbscan_params ->
             tuple("${umap_outdir}/${hdbscan_params_str}", umap_embeddings, hdbscan_params) }
+            .unique() // FIXME: not optimal hotfix
             .set { feed_me_into_hdbscan }
 
         clustering(feed_me_into_hdbscan)
@@ -690,7 +692,7 @@ workflow SingleImage {
         combinations_metadata_to_tsv(combinations_metadata)
 
         combinations_metadata_to_tsv.out.collect()
-            .map { tuple(params.img_path, [], params.outdir) }
+            .map { tuple(params.img_path, params.mask, params.outdir) }
             .set { data_for_report }
 
         generate_report(data_for_report)

--- a/main.nf
+++ b/main.nf
@@ -25,6 +25,7 @@ def extract_patchsize_from_lbp_params_list(lbp_params_list) {
     res[1]
 }
 
+// TODO: update to new config format (as used in grid_search.nf)
 def params_args_list = params.args.collect { k, v -> [k, v] }
 
 def lbp_params = params.args.lbp.collect { k, v -> [k, v] }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,27 @@
+params {
+    imgs_dir = null
+    img_path = null
+    imgs_and_masks_tsv = null
+    annot_suffix = 'annotation'
+
+    mask = null
+    background_color = null
+    outdir = "${System.getProperty("user.dir")}/outdir"
+
+    args_tsv = null
+    args = [:]
+    constargs = [:]
+}
+
+
 profiles {
     conda {
         conda.enabled = true
+        process.conda = "${projectDir}/envs/environment.yaml"
+    }
+    mamba {
+        conda.enabled = true
+        conda.useMamba = true
         process.conda = "${projectDir}/envs/environment.yaml"
     }
 }

--- a/templates/single_image.yaml
+++ b/templates/single_image.yaml
@@ -11,6 +11,7 @@ background_color: [255, 255, 255] # default is 0
 
 # --- specify parameters to test --- #
 args:
+
   lbp:
     patchsize: 242
     radii: [1,2,3,4,5] # don't specify to automatically calculate radii according to the default scheme
@@ -18,23 +19,47 @@ args:
     ncpus: 30
     outfile_name: 'lbp_result.npy'
     img_name: 'lbp_result'
+    
   dimred:
-    method: pca # [umap, pca, tsne]
+    method: pca
     n_components: 20
-    # n_neighbors: 20
-    # min_dist: 0.0
     random_state: 42
+    
+#     method: umap
+#     n_components: 20
+#     n_neighbors: 20
+#     min_dist: 0.0
+#     random_state: 42
+    
+#     method: tsne
+#     # TODO add params here
+    
   clustering:
-    method: gaussian_mixture # [hdbscan, k_means, affinity_propagation]
-    n_components: 4
-    covariance_type: 'diag'
-    tol: 0.005
-    random_state: 42
-    # damping: 0.7
-    # random_state: 42
+    # method: hdbscan
     # min_samples: 1
     # min_cluster_size: 300
     # cluster_selection_epsilon: 0.0
     # gen_min_span_tree: True
+    
+    # method: k_means
+    # n_clusters: 4
+    # random_state: 42
+    
+    # method: affinity_propagation
+    # damping: 0.7
+    # random_state: 42
+    
+    method: gaussian_mixture
+    n_components: 4
+    covariance_type: 'diag'
+    tol: 0.005
+    random_state: 42
+    
+    # method: leiden
+    # # TODO add params here
+    
+    
+
+    
 
     

--- a/templates/single_image.yaml
+++ b/templates/single_image.yaml
@@ -1,9 +1,12 @@
+# TODO: make the templates clean
+# TOOD: describe available methods in documentation instead
+
 # --- set img path and savedir --- #
-img_path: '/nfs/lbp_project/Thymus_test/TA11486161/spatial/otsu/img_white_bg.npy'
-outdir: '/lustre/scratch126/casm/team268im/os9/LBP/fastlbp-nextflow/gaus_mixt_test'
+img_path: '/path/to/image'
+outdir: '/path/to/outdir'
 
 # --- choose from the following or leave blank to not use the mask --- #
-mask: '/nfs/lbp_project/Thymus_test/TA11486161/spatial/otsu/mask.npy'
+mask: '/path/to/mask'
 background_color: [255, 255, 255] # default is 0 
 
 # mask: auto
@@ -11,30 +14,36 @@ background_color: [255, 255, 255] # default is 0
 
 # --- specify parameters to test --- #
 args:
-
   lbp:
     patchsize: 242
-    radii: [1,2,3,4,5] # don't specify to automatically calculate radii according to the default scheme
-    npoints: [7,13,19,26,32] # don't specify to automatically calculate number of points for each radius
+    # don't specify to automatically calculate radii according to the default scheme
+    radii: [1, 2, 3, 4, 5]
+    # don't specify to automatically calculate number of points for each radius
+    npoints: [7, 13, 19, 26, 32]
     ncpus: 30
     outfile_name: 'lbp_result.npy'
     img_name: 'lbp_result'
-    
   dimred:
     method: pca
     n_components: 20
     random_state: 42
+
+    # method: umap
+    # n_components: 20
+    # n_neighbors: 20
+    # min_dist: 0.0
+    # random_state: 42
     
-#     method: umap
-#     n_components: 20
-#     n_neighbors: 20
-#     min_dist: 0.0
-#     random_state: 42
-    
-#     method: tsne
-#     # TODO add params here
+    # # TODO add params here
+    # method: tsne
     
   clustering:
+    method: gaussian_mixture
+    n_components: 4
+    covariance_type: 'diag'
+    tol: 0.005
+    random_state: 42
+
     # method: hdbscan
     # min_samples: 1
     # min_cluster_size: 300
@@ -49,17 +58,5 @@ args:
     # damping: 0.7
     # random_state: 42
     
-    method: gaussian_mixture
-    n_components: 4
-    covariance_type: 'diag'
-    tol: 0.005
-    random_state: 42
-    
-    # method: leiden
     # # TODO add params here
-    
-    
-
-    
-
-    
+    # method: leiden

--- a/templates/single_image.yaml
+++ b/templates/single_image.yaml
@@ -1,10 +1,10 @@
 # --- set img path and savedir --- #
-img_path: '/path/to/image'
-outdir: '/path/to/outdir'
+img_path: '/nfs/lbp_project/Thymus_test/TA11486161/spatial/otsu/img_white_bg.npy'
+outdir: '/lustre/scratch126/casm/team268im/os9/LBP/fastlbp-nextflow/gaus_mixt_test'
 
 # --- choose from the following or leave blank to not use the mask --- #
-# mask: '/path/to/mask'
-# background_color: [255, 255, 255] # default is 0 
+mask: '/nfs/lbp_project/Thymus_test/TA11486161/spatial/otsu/mask.npy'
+background_color: [255, 255, 255] # default is 0 
 
 # mask: auto
 # background_color: light/dark
@@ -12,21 +12,29 @@ outdir: '/path/to/outdir'
 # --- specify parameters to test --- #
 args:
   lbp:
-    patchsize: 10
-    radii: [1, 5] # don't specify to automatically calculate radii according to the default scheme
-    npoints: [6, 12] # don't specify to automatically calculate number of points for each radius
+    patchsize: 242
+    radii: [1,2,3,4,5] # don't specify to automatically calculate radii according to the default scheme
+    npoints: [7,13,19,26,32] # don't specify to automatically calculate number of points for each radius
     ncpus: 30
     outfile_name: 'lbp_result.npy'
     img_name: 'lbp_result'
   dimred:
-    method: umap # [umap, pca, tsne]
+    method: pca # [umap, pca, tsne]
     n_components: 20
-    n_neighbors: 20
-    min_dist: 0.0
+    # n_neighbors: 20
+    # min_dist: 0.0
     random_state: 42
   clustering:
-    method: hdbscan # [hdbscan, k_means]
-    min_samples: 1
-    min_cluster_size: 300
-    cluster_selection_epsilon: 0.0
-    gen_min_span_tree: True
+    method: gaussian_mixture # [hdbscan, k_means, affinity_propagation]
+    n_components: 4
+    covariance_type: 'diag'
+    tol: 0.005
+    random_state: 42
+    # damping: 0.7
+    # random_state: 42
+    # min_samples: 1
+    # min_cluster_size: 300
+    # cluster_selection_epsilon: 0.0
+    # gen_min_span_tree: True
+
+    


### PR DESCRIPTION
- New methods added for the clustering step:
    - Leiden clustering (using [implementation](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.leiden.html) from the [Scanpy](https://scanpy.readthedocs.io/en/stable/) package)
   - Affinity Propagation (using [sklearn implementation](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AffinityPropagation.html))
   - Gaussian Mixture (using [sklearn implementation](https://scikit-learn.org/stable/modules/generated/sklearn.mixture.GaussianMixture.html))

- Plots generated in the Grid Search mode report are created with the `include_plotlyjs='cdn'` parameter instead of `True` (see [Plotly docs](https://plotly.com/python-api-reference/generated/plotly.graph_objects.Figure.html#plotly.graph_objects.Figure.to_html) for details)

